### PR TITLE
argo/apps/monitoring: Enable sidecar

### DIFF
--- a/argo/apps/monitoring/values.yaml
+++ b/argo/apps/monitoring/values.yaml
@@ -48,6 +48,13 @@ grafana:
       defaultMode: 0440
       mountPath: /etc/secrets/dex_oauth
       readOnly: true
+  sidecar:
+    dashboards:
+      enabled: true
+      labelValue: "true"
+    datasources:
+      enabled: true
+      labelValue: "true"
   # Disable as its not currently working
   # plugins:
   #   - grafana-oncall-app


### PR DESCRIPTION
Enable the sidecar for grafana so that we can load datasources and dashboards independently