### PR TITLE
fix(ansible): Fix ArgoCD SSH credentials namespace

### DIFF
--- a/ansible/playbooks/roles/k3s/services/tasks/argocd.yml
+++ b/ansible/playbooks/roles/k3s/services/tasks/argocd.yml
@@ -151,7 +151,7 @@
         name: "{{ item.name }}-repo"
         #
         # TODO: Revisit this as its weird to pull the namespace like that for tailscale.
-        namespace: "{{ internal_ingress_namespace }}"
+        namespace: "{{ argocd_k8s_namespace }}"
         labels:
           argocd.argoproj.io/secret-type: repository
       stringData:


### PR DESCRIPTION

This was accidentally installed in a wrong namespace.
