### PR TITLE
fix(argo/lib): Fix missing closing bracket

### DIFF
--- a/argo/lib/appset.libsonnet
+++ b/argo/lib/appset.libsonnet
@@ -58,7 +58,7 @@
             repoURL: 'git@github.com:Voytechnology/homelab.git',
             targetRevision: 'HEAD',
             ref: 'values',
-          },
+          }],
         },
       },
     },


### PR DESCRIPTION

Accidentally deleted
