### PR TITLE
fix(ansible): Increase Max User Instances

### DIFF
--- a/ansible/playbooks/roles/k3s/prereq/tasks/main.yml
+++ b/ansible/playbooks/roles/k3s/prereq/tasks/main.yml
@@ -19,6 +19,13 @@
     reload: yes
   when: ansible_all_ipv6_addresses
 
+- name: Increase Max User Instances
+  sysctl:
+    name: fs.inotify.max_user_instances
+    value: 1024
+    state: present
+    reload: yes
+
 - name: Increase Max User Watches
   sysctl:
     name: fs.inotify.max_user_watches


### PR DESCRIPTION

Cluster is plagued by constant inotify watcher exhaustion.
