### PR TITLE
fix(monitoring): Disable clustering across alloy

### DIFF
--- a/argo/apps/monitoring/values.yaml
+++ b/argo/apps/monitoring/values.yaml
@@ -99,7 +99,7 @@ alloy:
               number: 12347
   alloy:
     clustering:
-      enabled: true
+      enabled: false
     stabilityLevel: experimental
     configMap:
       content: |


### PR DESCRIPTION

Disabling it in prometheus alone didn't work
