### PR TITLE
fix(monitoring): Fix bad comments in Alloy

### DIFF
--- a/argo/apps/monitoring/values.yaml
+++ b/argo/apps/monitoring/values.yaml
@@ -113,9 +113,9 @@ alloy:
         }
 
         prometheus.operator.servicemonitors "services" {
-          # clustering {
-          #   enabled = true
-          # }
+          // clustering {
+          //   enabled = true
+          // }
 
           forward_to = [prometheus.remote_write.mimir.receiver]
         }


### PR DESCRIPTION

double slash is legal, editor default hashtag is not.
