### PR TITLE
feat(openfaas): Add PodMonitor and disable prometheus

### DIFF
--- a/argo/apps/monitoring/values.yaml
+++ b/argo/apps/monitoring/values.yaml
@@ -135,6 +135,10 @@ alloy:
           forward_to = [prometheus.remote_write.mimir.receiver]
         }
 
+        prometheus.operator.podmonitors "pods" {
+          forward_to = [prometheus.remote_write.mimir.receiver]
+        }
+
         prometheus.exporter.cadvisor "cadvisor" {}
 
         prometheus.scrape "cadvisor" {

--- a/argo/apps/openfaas/default.values.yaml
+++ b/argo/apps/openfaas/default.values.yaml
@@ -1,0 +1,21 @@
+prometheus:
+  # Do not create a prometheus instance as we have an already existing
+  # monitoring stack.
+  create: false
+
+extraObjects:
+  podMonitor:
+    apiVersion: monitoring.coreos.com/v1
+    kind: PodMonitor
+    metadata:
+      name: openfaas
+    spec:
+      namespaceSelector:
+        matchNames:
+          - openfaas
+      selector:
+        matchLabels: {}  # Match all pods
+      podMetricsEndpoints:
+        - port: metrics  # Most OpenFaaS components expose on 'metrics'
+          interval: 15s
+          path: /metrics

--- a/argo/appsets/openfaas.jsonnet
+++ b/argo/appsets/openfaas.jsonnet
@@ -38,6 +38,8 @@ local openfaasSource = helm.new('openfaas',
   },
 );
 
+local extraObjects = helm.extraObjects('openfaas')
 
 appset.new('openfaas', 'openfaas')
 + appset.addSource(openfaasSource)
++ appset.addSource(extraObjects)


### PR DESCRIPTION

Add PodMonitor and disable the prometheus instance provided with OpenFaaS as we already have our own.

The change also required a change to the alloy config to also monitor the PodMonitors
