### PR TITLE
fix(openfaas): Create prometheus again

### DIFF
--- a/argo/apps/openfaas/default.values.yaml
+++ b/argo/apps/openfaas/default.values.yaml
@@ -1,8 +1,3 @@
-prometheus:
-  # Do not create a prometheus instance as we have an already existing
-  # monitoring stack.
-  create: false
-
 # Use the same namespace as openfaas itself for simplicity
 # Whow knows is this a good idea or not
 functionNamespace: openfaas


### PR DESCRIPTION

No idea how to change the reference to external. Pod monitor will be replaced by a service monitor afterwards, and maybe configure remote write for the enabled prometheus somehow?
