### PR TITLE
fix(longhorn): use correct value for hostname

### DIFF
--- a/argo/appsets/longhorn.jsonnet
+++ b/argo/appsets/longhorn.jsonnet
@@ -7,6 +7,7 @@ local source = helm.new(
     longhorn: {
       ingress: util.ingress('longhorn', class='internal-login') {
         secureBackends: true,
+        host: 'longhorn.{{ .domain }}',
         tls: true,
         tlsSecret: 'longhorn-tls',
       },


### PR DESCRIPTION
Why do you have to be like this
