### PR TITLE
Enable Envoy XListenerSet for Jellyfin routing

### DIFF
--- a/argo/apps/envoy/values.yaml
+++ b/argo/apps/envoy/values.yaml
@@ -1,0 +1,5 @@
+config:
+  envoyGateway:
+    gatewayAPI:
+      enabled:
+        - XListenerSet


### PR DESCRIPTION
## Summary
- Enable Envoy Gateway `XListenerSet` support in the public `envoy` app values
- Unblock the Jellyfin Gateway API listener attachment path used by the media deployment
- Keep the change limited to generic Gateway API capability, without adding app-specific hostnames or secrets

## Testing
- Not run (not requested)