### PR TITLE
Enable external-dns for Gateway HTTPRoutes

### DIFF
--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -10,3 +10,4 @@ external-dns:
           key: token
   extraArgs:
     - "--annotation-filter=dns.kubernetes.io/exclude notin (true)"
+    - "--source=gateway-httproute"


### PR DESCRIPTION
## Summary
- Configure external-dns to watch Gateway API HTTPRoutes
- Allow Grafana and other Gateway-backed services to publish DNS records

## Testing
- Not run (not requested)