### PR TITLE
grafana: enable oauth_allow_insecure_email_lookup for Dex auth whitelist

### DIFF
--- a/argo/apps/monitoring/values.yaml
+++ b/argo/apps/monitoring/values.yaml
@@ -15,6 +15,7 @@ grafana:
       scopes: openid email profile groups offline_access
       oauth_skip_org_role_sync: true
       allow_sign_up: false
+      oauth_allow_insecure_email_lookup: true
       auth_url: "https://login.{{ .Values.domain }}/auth"
       token_url: "https://login.{{ .Values.domain }}/token"
       api_url: "https://login.{{ .Values.domain }}/userinfo"

--- a/scripts/grafana-reset-admin
+++ b/scripts/grafana-reset-admin
@@ -1,0 +1,15 @@
+#!/bin/zsh
+set -e
+
+NAMESPACE=monitoring
+DEPLOY=monitoring-grafana
+SECRET=monitoring-grafana
+NEW_PASS="$(openssl rand -base64 48 | tr -d '/+=' | head -c 60)Aa1!"
+
+kubectl patch secret "$SECRET" -n "$NAMESPACE" -p \
+  "{\"data\":{\"admin-password\":\"$(echo -n "$NEW_PASS" | base64)\"}}"
+
+echo -n "$NEW_PASS" | kubectl exec -n "$NAMESPACE" deploy/"$DEPLOY" -i -- \
+  sh -c 'cat > /tmp/newpass && /usr/share/grafana/bin/grafana cli admin reset-admin-password "$(cat /tmp/newpass)"'
+
+echo "New admin password: $NEW_PASS"


### PR DESCRIPTION
Adds `oauth_allow_insecure_email_lookup: true` so Grafana matches pre-existing local users by email when they authenticate via Dex/Google. This enables a static user whitelist with manually assigned roles — users must be created in Grafana ahead of time, and only those with matching Google emails can log in.