### PR TITLE
grafana: fix skip_org_role_sync key name

### DIFF
--- a/argo/apps/monitoring/values.yaml
+++ b/argo/apps/monitoring/values.yaml
@@ -13,7 +13,7 @@ grafana:
       enabled: true
       name: "Dex"
       scopes: openid email profile groups offline_access
-      oauth_skip_org_role_sync: true
+      skip_org_role_sync: true
       allow_sign_up: false
       oauth_allow_insecure_email_lookup: true
       auth_url: "https://login.{{ .Values.domain }}/auth"


### PR DESCRIPTION
Grafana 13 uses `skip_org_role_sync` (not `oauth_skip_org_role_sync`) under `auth.generic_oauth` to prevent role sync from the OIDC provider.