### PR TITLE
monitoring: wire grafana-data PVC into grafana deployment

### DIFF
--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -93,7 +93,6 @@ local withSyncWave(wave) = {
           )
         + container.withVolumeMounts([
             volumeMount.new('grafana-data', '/var/lib/grafana', false),
-            volumeMount.new('grafana-dashboards-sidecar', '/var/lib/grafana/dashboards/default', false),
           ]),
 
       grafana_data_pvc:
@@ -104,15 +103,13 @@ local withSyncWave(wave) = {
 
       grafana_http_route: $.httpRoute,
 
-      // grafana_deployment+:
-      //   k.apps.v1.deployment.mixin.spec.template.spec.withContainers([
-      //     $.grafana_container,
-      //     $.dashboardSidecar,
-      //   ])
-      //   + k.apps.v1.deployment.mixin.spec.template.spec.withVolumesMixin([
-      //     volume.fromPersistentVolumeClaim('grafana-data', 'grafana-data'),
-      //     volume.emptyDir.new('grafana-dashboards-sidecar'),
-      //   ])
-      //   + withSyncWave(0),
+      // Dashboard delivery goes through configmap_mounts (see grafana lib's
+      // configmaps.libsonnet), not a sidecar, so the deployment only needs
+      // the grafana-data volume wired up to back the PVC above.
+      grafana_deployment+:
+        k.apps.v1.deployment.mixin.spec.template.spec.withVolumesMixin([
+          volume.fromPersistentVolumeClaim('grafana-data', 'grafana-data'),
+        ])
+        + withSyncWave(0),
     }
 }


### PR DESCRIPTION
## Summary
`bet1-monitoring` was failing to sync in Argo CD (`OutOfSync`/`Missing`). The `grafana` Deployment was rejected by the API server because `grafana_container` mounted `grafana-data` and `grafana-dashboards-sidecar` volumes that the Deployment never defined — the wiring block was left commented out in a prior commit, and it also referenced a `$.dashboardSidecar` container that has no implementation anywhere in the repo.

## Fix
- Drop the `grafana-dashboards-sidecar` volumeMount (dashboards are already delivered via `configmap_mounts`, no sidecar needed).
- Wire the `grafana-data` volume from the existing `grafana-data` PVC into `grafana_deployment`, giving Grafana persistent storage for its sqlite DB (users, alerting state, etc).

## Validation
Rendered locally with `scripts/tk-show` against the real vendor tree/jpath, mirroring the Argo CD CMP:
```
TANKA_DANGEROUS_ALLOW_REDIRECT=true TANKA_NAMESPACE=monitoring TANKA_CLUSTER=bet1 TANKA_APP=monitoring \
  TANKA_OVERRIDES='{"cluster": "bet1", "domain": "bet1.bednarzak.com", "metricsNamespace": "metrics-system", "namespace": "monitoring"}' \
  scripts/tk-show argo/apps/monitoring
```
Every `volumeMount` on the grafana container now has a matching `volume` (grafana-data → PVC, plus the four config ConfigMaps), and the PVC itself renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)