### PR TITLE
monitoring: fix grafana deployment/PVC sync-wave ordering

### DIFF
--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -105,11 +105,12 @@ local withSyncWave(wave) = {
 
       // Dashboard delivery goes through configmap_mounts (see grafana lib's
       // configmaps.libsonnet), not a sidecar, so the deployment only needs
-      // the grafana-data volume wired up to back the PVC above.
+      // the grafana-data volume wired up to back the PVC above. Sync-wave 2
+      // so the PVC (wave 1) exists before the pod tries to mount it.
       grafana_deployment+:
         k.apps.v1.deployment.mixin.spec.template.spec.withVolumesMixin([
           volume.fromPersistentVolumeClaim('grafana-data', 'grafana-data'),
         ])
-        + withSyncWave(0),
+        + withSyncWave(2),
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #278. That PR wired the grafana-data PVC into the grafana Deployment but left the Deployment at the default sync-wave (0) while the PVC syncs at wave 1. Argo CD applied the Deployment before the PVC existed, so the grafana pod got stuck:

```
0/2 nodes are available: persistentvolumeclaim "grafana-data" not found. not found
```

## Fix
Bump `grafana_deployment` to sync-wave 2 so it applies strictly after the PVC (wave 1).

## Validation
Re-rendered with `scripts/tk-show` (same overrides as the Argo CD CMP) and confirmed the annotations:
- PVC: `argocd.argoproj.io/sync-wave: "1"`
- Deployment: `argocd.argoproj.io/sync-wave: "2"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)