### PR TITLE
monitoring: set fsGroup on grafana pod so it can write its PVC

### DIFF
--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -107,10 +107,15 @@ local withSyncWave(wave) = {
       // configmaps.libsonnet), not a sidecar, so the deployment only needs
       // the grafana-data volume wired up to back the PVC above. Sync-wave 2
       // so the PVC (wave 1) exists before the pod tries to mount it.
+      //
+      // fsGroup is required because the grafana image runs as uid 472, but a
+      // fresh PVC mounts root-owned — without it the container can't write
+      // to /var/lib/grafana and crashloops on "Permission denied".
       grafana_deployment+:
         k.apps.v1.deployment.mixin.spec.template.spec.withVolumesMixin([
           volume.fromPersistentVolumeClaim('grafana-data', 'grafana-data'),
         ])
+        + k.apps.v1.deployment.mixin.spec.template.spec.securityContext.withFsGroup(472)
         + withSyncWave(2),
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #278/#279. The grafana-data PVC mounts root-owned by default, but the grafana image runs as uid 472 (non-root). Without `fsGroup` set, the container crashlooped:

```
GF_PATHS_DATA='/var/lib/grafana' is not writable.
mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied
```

## Fix
Set `securityContext.fsGroup: 472` on the grafana pod so kubelet chowns the mounted PVC to a group the container can write to.

## Validation
Re-rendered with `scripts/tk-show`; confirmed `spec.template.spec.securityContext.fsGroup: 472` on the rendered Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)