### PR TITLE
monitoring: fix mixin dashboards never reaching Grafana

### DIFF
--- a/argo/apps/monitoring/jsonnetfile.json
+++ b/argo/apps/monitoring/jsonnetfile.json
@@ -4,7 +4,26 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs.git"
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
         }
       },
       "version": "master"

--- a/argo/apps/monitoring/jsonnetfile.lock.json
+++ b/argo/apps/monitoring/jsonnetfile.lock.json
@@ -4,6 +4,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "a1d61cce1da59c71409b99b5c7568511fec661ea",
+      "sum": "342u++/7rViR/zj2jeJOjshzglkZ1SY+hFNuyCBFMdc="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": ""
         }
@@ -15,11 +25,31 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "FqEJAICz9T90PMJLW8i4HXazyWQPNzi68A8UauXa7GQ="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "ksonnet-util"
         }
       },
       "version": "d01205894528f52fd1d9f991aa8475abfb50bead",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "mixin-utils"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "zVkvwae4zHP6xeIoDvde/wldI6ClprFjnk50mMD9/z4="
     },
     {
       "source": {

--- a/argo/apps/monitoring/mixins.libsonnet
+++ b/argo/apps/monitoring/mixins.libsonnet
@@ -1,2 +1,10 @@
-(import "github.com/grafana/jsonnet-libs/argocd-mixin/mixin.libsonnet") +
-(import "github.com/grafana/jsonnet-libs/envoy-mixin/mixin.libsonnet")
+// grafana.addMixinDashboards() (see the vendored grafana/dashboards.libsonnet)
+// expects an object keyed by mixin name, each value being that mixin's own
+// jsonnet-libs mixin object — not a single object with all mixins merged
+// together. Merging them flatly (the previous shape here) meant
+// addMixinDashboards's `mixins[name].grafanaDashboards` lookup never matched
+// anything, so no dashboard ever made it into a ConfigMap.
+{
+  argocd: import 'github.com/grafana/jsonnet-libs/argocd-mixin/mixin.libsonnet',
+  envoy: import 'github.com/grafana/jsonnet-libs/envoy-mixin/mixin.libsonnet',
+}


### PR DESCRIPTION
## Summary
Follow-up to #278/#279/#280. Grafana was healthy but logging repeating errors:

```
error="stat /grafana/dashboards: no such file or directory"
```

`grafana.addMixinDashboards()` expects an object keyed by mixin name (each value the mixin's own jsonnet-libs object, looked up as `mixins[name].grafanaDashboards`). `mixins.libsonnet` instead flattened `argocd-mixin + envoy-mixin` into one merged object, so every `mixins[name].grafanaDashboards` lookup silently missed — no dashboard ever made it into a ConfigMap, yet the provisioner still referenced a path with nothing mounted there.

## Fix
- Key `mixins.libsonnet` by mixin name, matching what `addMixinDashboards` expects.
- That surfaced two missing transitive jsonnet deps `envoy-mixin` needs for its `dashboards.libsonnet`: `grafana-builder` (jsonnet-libs subdir) and the old `grafonnet-lib` package (envoy-mixin predates grafonnet-7.0's new API). Added both via `jb install`.

## Validation
`tk show` now renders `dashboards-0` (general/argocd) and `dashboards-envoy-0` ConfigMaps with real dashboard JSON, `grafana-dashboard-provisioning` references matching paths, and every container `volumeMount` still has a matching pod `volume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)