### PR TITLE
monitoring: stop grafana_container env override from wiping GF_PATHS_CONFIG

### DIFF
--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -83,7 +83,14 @@ local withSyncWave(wave) = {
       },
 
       grafana_container+::
-        container.withEnv([
+        // withEnv (unlike withEnvMixin) replaces the whole env list, which
+        // was silently wiping out the base container's GF_PATHS_CONFIG and
+        // GF_INSTALL_PLUGINS (set via withEnvMap in the vendored
+        // deployment.libsonnet). That meant grafana-server fell back to its
+        // baked-in /etc/grafana/grafana.ini default instead of our
+        // configmap-mounted config, so OAuth (and everything else in
+        // iniConfig) was silently never applied.
+        container.withEnvMixin([
           { name: 'GF_AUTH_GENERIC_OAUTH_CLIENT_ID', valueFrom: { secretKeyRef: { name: 'grafana-cloud', key: 'oauth-client-id' } } },
           { name: 'GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET', valueFrom: { secretKeyRef: { name: 'grafana-cloud', key: 'oauth-client-secret' } } },
         ])


### PR DESCRIPTION
## Summary
Follow-up to #278–#281. Grafana was Healthy and dashboards loaded, but Dex OAuth login never appeared — `/login`'s bootData showed `"oauth":{}` despite the ConfigMap having a correct `[auth.generic_oauth]` section.

## Root cause
`grafana_container+::` set OAuth env vars with `container.withEnv([...])`, which **replaces** the entire `env` list rather than merging (`withEnvMixin` is the merging variant). That silently dropped the base container's `GF_PATHS_CONFIG` and `GF_INSTALL_PLUGINS` (set via `withEnvMap` in the vendored `deployment.libsonnet`).

Without `GF_PATHS_CONFIG`, grafana-server fell back to its baked-in `/etc/grafana/grafana.ini` (the stock, all-commented-out template) instead of loading the configmap-mounted config at `/etc/grafana-config/grafana.ini` — so none of our `iniConfig` (OAuth, root_url, etc.) was ever actually applied, despite looking correct in the ConfigMap.

Confirmed live before the fix:
- Pod env only had the two OAuth vars, no `GF_PATHS_CONFIG`.
- `/etc/grafana/grafana.ini` in the running container was the stock template.
- Login page bootData: `"oauth":{}`.

## Fix
Switch to `container.withEnvMixin([...])` so the OAuth vars append instead of replacing.

## Validation
`tk show` now renders all four env vars on the container: `GF_INSTALL_PLUGINS`, `GF_PATHS_CONFIG`, `GF_AUTH_GENERIC_OAUTH_CLIENT_ID`, `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)