### PR TITLE
monitoring: bump grafana image to 13.1.3 (latest)

### DIFF
--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -77,6 +77,15 @@ local withSyncWave(wave) = {
     + grafana.addDatasource('metrics', $.metricsDatasource)
     + grafana.addMixinDashboards(mixins)
     + {
+      // The vendored grafana.libsonnet defaults to grafana/grafana:8.2.5
+      // (2021). Renovate's jsonnet custom manager only tracks
+      // `targetRevision = '...'` assignments, not image tags, so this isn't
+      // auto-bumped — check https://github.com/grafana/grafana/releases
+      // occasionally and bump by hand.
+      _images+:: {
+        grafana: 'grafana/grafana:13.1.3',
+      },
+
       _config+:: {
         # Dogfooding my own feature!
         configmap_binpack: true,


### PR DESCRIPTION
## Summary
The vendored `grafana.libsonnet` defaults to `grafana/grafana:8.2.5` (2021), never overridden. Bump to the current latest stable (`13.1.3` as of writing, cross-checked via Docker Hub tags and GitHub releases).

Renovate's jsonnet custom manager only tracks `targetRevision = '...'` assignments (see `renovate.json`), not raw image tag strings, so this won't be auto-bumped going forward — left a comment to check by hand occasionally.

## Risk
Low: the `grafana-data` PVC is brand new (added a few commits ago in this same fix series), so there's no real dashboard/user data riding on this — worst case is wiping an empty PVC and letting it reinitialize.

## Validation
`tk show` renders the Deployment with `grafana/grafana:13.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)