### PR TITLE
metrics: fix mimir block shipping by configuring SeaweedFS S3 identity

### DIFF
--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -18,10 +18,11 @@ mimir {
     aws_region: 'us-east-1', # unused
     storage_backend: 's3',
     storage_s3_endpoint: 'seaweedfs-s3.%s.svc.cluster.local:8333' % $._namespace,
-    # SeaweedFS runs with enableAuth: false, so any static credentials are
-    # accepted. They must be non-empty to stop the AWS SDK from falling back
-    # to the EC2 instance metadata service (169.254.169.254), which would
-    # hang and time out in this homelab (no cloud metadata endpoint).
+    # Must match the S3 gateway admin identity configured in
+    # argo/apps/metrics/seaweedfs.values.yaml (filer.s3.enableAuth / s3.credentials).
+    # Also must be non-empty to stop the AWS SDK from falling back to the EC2
+    # instance metadata service (169.254.169.254), which would hang and time
+    # out in this homelab (no cloud metadata endpoint).
     storage_s3_access_key_id: 'mimir',
     storage_s3_secret_access_key: 'mimir',
     blocks_storage_bucket_name: 'mimir',

--- a/argo/apps/metrics/seaweedfs.values.yaml
+++ b/argo/apps/metrics/seaweedfs.values.yaml
@@ -10,6 +10,21 @@ volume:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 
+# Static admin credentials for the S3 gateway, matching the
+# storage_s3_access_key_id/storage_s3_secret_access_key used by mimir
+# (see argo/apps/metrics/main.jsonnet). enableAuth: false does NOT mean
+# "accept any credentials" -- it means "run the S3 gateway with no
+# identities configured at all", which only accepts unsigned/anonymous
+# requests. Mimir's S3 client always sends SigV4-signed requests when
+# given static credentials, so those get rejected with "Signed request
+# requires setting up SeaweedFS S3 authentication" unless an identity
+# matching the access key is configured here.
+s3:
+  credentials:
+    admin:
+      accessKey: mimir
+      secretKey: mimir
+
 filer:
   replicas: 1
   annotations:
@@ -17,7 +32,7 @@ filer:
   s3:
     enabled: true
     replicas: 1
-    enableAuth: false
+    enableAuth: true
     annotations:
       argocd.argoproj.io/sync-wave: "0"
     createBuckets:


### PR DESCRIPTION
## Problem

Grafana's mimir datasource was returning "empty ring" errors. `ingester-0` was crash-looping with `no space left on device` on its 1Gi PVC.

## Root cause

Block shipping from mimir's ingester to SeaweedFS S3 has never succeeded — `mimir.shipper.json` showed `shipped: {}` despite ~25 days / ~84 locally-compacted blocks. Live logs showed:

```
uploading new block to long-term storage failed ... err="failed to upload index: ... upload s3 object: Signed request requires setting up SeaweedFS S3 authentication"
```

`filer.s3.enableAuth: false` does not mean "accept any credentials" — it means the S3 gateway runs with **zero identities configured**, which only accepts unsigned/anonymous requests. Mimir's S3 client always sends SigV4-signed requests when given static credentials (`storage_s3_access_key_id`/`storage_s3_secret_access_key`), so every block upload was rejected. Since nothing ever shipped, local blocks + WAL accumulated until the 1Gi PVC filled completely, at which point the ingester couldn't even start (compaction requires 512MB free for TSDB's chunk-segment preallocation — a hardcoded Prometheus TSDB constant, not configurable via Mimir flags).

## Fix

- `argo/apps/metrics/seaweedfs.values.yaml`: enable `filer.s3.enableAuth` and configure an explicit S3 admin identity (`mimir`/`mimir`) matching what mimir already sends, so signed requests validate successfully.
- `argo/apps/metrics/main.jsonnet`: correct the stale comment about `enableAuth: false`.

## Live recovery (already applied directly to the cluster, ahead of this merge)

- Scaled `ingester-0` to 0, attached a debug pod to its PVC, and deleted the unshipped local WAL/blocks (none of it was ever durable, since shipping never worked) to get it back under the 1Gi limit.
- Manually forced a flush (`/ingester/flush`) to confirm the upload error, and verified the SeaweedFS bucket (`mimir`) and S3 gateway have plenty of capacity (33/47 volume slots free) — this was never a real storage-capacity problem, just an auth mismatch.

## Validation

- `helm template seaweedfs --repo https://seaweedfs.github.io/seaweedfs/helm --version 4.40.0 -f argo/apps/metrics/seaweedfs.values.yaml` — confirms the rendered `seaweedfs_s3_config` secret now contains identity `anvAdmin` with `accessKey: mimir` / `secretKey: mimir` and `Admin,Read,Write` actions, and `-s3.config=/etc/sw/seaweedfs_s3_config` is now passed to the filer.
- `TANKA_NAMESPACE=metrics-system scripts/tk-show argo/apps/metrics` — renders cleanly, no syntax errors.
- Once merged, Argo CD's auto-sync (self-heal enabled) will reconfigure the SeaweedFS filer/S3 pod with the new identity; ingester block shipping should then succeed within the next `ship-interval` (1m) after a block is cut, and local disk usage should stay well under the 1Gi limit going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)