### PR TITLE
metrics: drop query-scheduler podAntiAffinity on single-node cluster

### DIFF
--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -70,7 +70,17 @@ mimir {
   querier_deployment+: deployment.mixin.spec.withReplicas(1),
   query_frontend_deployment+: deployment.mixin.spec.withReplicas(1),
   store_gateway_statefulset+: statefulSet.mixin.spec.withReplicas(1),
-  query_scheduler_deployment+: deployment.mixin.spec.withReplicas(1),
+  // query-scheduler.libsonnet unconditionally sets a hard podAntiAffinity
+  // (unlike ingester/store-gateway, which respect the
+  // *_allow_multiple_replicas_on_same_node config above) combined with
+  // maxSurge(1)/maxUnavailable(0). On this single-node homelab cluster that
+  // deadlocks forever: every pod-template change tries to schedule a second
+  // query-scheduler pod on the same node before killing the old one, which
+  // the anti-affinity rule forbids, leaving the new pod Pending and the
+  // rollout permanently stuck ("exceeded its progress deadline").
+  query_scheduler_deployment+:
+    deployment.mixin.spec.withReplicas(1)
+    + { spec+: { template+: { spec+: { affinity: null } } } },
 
   compactor_container+: k.util.resourcesRequests('100m', '128Mi'),
   distributor_container+: k.util.resourcesRequests('100m', '128Mi'),


### PR DESCRIPTION
## Problem

The `bet1-metrics` Argo Application has been stuck `Degraded` / continuously retrying sync, even after #284 fixed the actual mimir/SeaweedFS shipping bug. Root cause is unrelated to that fix:

```
Deployment "query-scheduler" exceeded its progress deadline
```

## Root cause

`query-scheduler.libsonnet`'s `newQuerySchedulerDeployment` unconditionally applies:

- a hard `podAntiAffinity` (no two `query-scheduler` pods on the same node), and
- `maxSurge(1)` / `maxUnavailable(0)` rolling update strategy (surge a new pod before killing the old one)

Unlike ingester/store-gateway, query-scheduler has no config knob to disable the anti-affinity (this repo already sets `ingester_allow_multiple_replicas_on_same_node` / `store_gateway_allow_multiple_replicas_on_same_node` for exactly this reason).

On this single-node (`s1-bet1`) cluster, that combination deadlocks permanently: any pod-template change tries to schedule a *second* query-scheduler pod on the same node before killing the first, which anti-affinity forbids. The surge pod sits `Pending` forever, and the rollout can never complete.

This left a stray `Pending` pod (`query-scheduler-5668847bf9-qlztz`) from a rollout **18 days ago**, permanently degrading the Argo Application's health status.

## Fix

`argo/apps/metrics/main.jsonnet`: null out `spec.template.spec.affinity` on `query_scheduler_deployment`, the same pattern already used elsewhere in this file for single-node homelab constraints.

## Validation

- `TANKA_NAMESPACE=metrics-system scripts/tk-show argo/apps/metrics` — renders cleanly; confirmed `affinity: null` on the `query-scheduler` Deployment, rest of the spec unchanged.
- Once merged, Argo CD's auto-sync (self-heal) will roll query-scheduler forward; the new pod should schedule immediately since the anti-affinity constraint is gone, clearing the stuck old ReplicaSets and resolving the app's `Degraded` status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)