### PR TITLE
monitoring: add mimir grafana mixin

### DIFF
--- a/argo/apps/monitoring/jsonnetfile.json
+++ b/argo/apps/monitoring/jsonnetfile.json
@@ -40,6 +40,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/mimir.git",
+          "subdir": "operations/mimir-mixin"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
           "subdir": "1.35"
         }

--- a/argo/apps/monitoring/jsonnetfile.lock.json
+++ b/argo/apps/monitoring/jsonnetfile.lock.json
@@ -54,6 +54,26 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/mimir.git",
+          "subdir": "operations/mimir-mixin"
+        }
+      },
+      "version": "f828e3db1aedb8bd5d170705ad4f58f6138f437a",
+      "sum": "JWI1ZnyB23osWGvBgBOx2lZ0KSPCVkrMfXAQAsad++k="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/rollout-operator.git",
+          "subdir": "operations/rollout-operator-mixin"
+        }
+      },
+      "version": "a0d115714858140ccc686e30f24719bc303e734d",
+      "sum": "+A9iB+GdwZepQWGYAq/hinLOcdWQQQaApATnzvDMJEE="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
           "subdir": "1.35"
         }

--- a/argo/apps/monitoring/mixins.libsonnet
+++ b/argo/apps/monitoring/mixins.libsonnet
@@ -7,4 +7,5 @@
 {
   argocd: import 'github.com/grafana/jsonnet-libs/argocd-mixin/mixin.libsonnet',
   envoy: import 'github.com/grafana/jsonnet-libs/envoy-mixin/mixin.libsonnet',
+  mimir: import 'github.com/grafana/mimir/operations/mimir-mixin/mixin.libsonnet',
 }


### PR DESCRIPTION
## Summary
- Vendor `github.com/grafana/mimir/operations/mimir-mixin` via `jb install`
- Load the mimir mixin's dashboards into Grafana in `argo/apps/monitoring/mixins.libsonnet`, alongside the existing argocd/envoy mixins

## Validation
- `jsonnet -J vendor -e "..."` confirms `mimir.grafanaDashboards` resolves (27 dashboards)
- `TANKA_NAMESPACE=monitoring scripts/tk-show argo/apps/monitoring` renders cleanly, producing `dashboards-mimir-*` ConfigMaps mounted into the Grafana deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)