### PR TITLE
metrics: scrape Mimir's own components so self-monitoring metrics land in Mimir

### DIFF
--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -9,6 +9,21 @@ local withSyncWave(wave) = {
   metadata+: { annotations+: { 'argocd.argoproj.io/sync-wave': std.toString(wave) } },
 };
 
+// withScrapeAnnotations adds prometheus.io/scrape annotations to a pod
+// template so Alloy's annotation-based pod discovery (see
+// argo/apps/monitoring/values.yaml) picks up the component's own /metrics
+// endpoint. Without this, none of Mimir's components are scraped by
+// anything, so Mimir never has its own cortex_*/mimir_* self-monitoring
+// metrics (what the mimir-mixin dashboards query) even though it happily
+// stores everything remote-written to it.
+local withScrapeAnnotations = {
+  spec+: { template+: { metadata+: { annotations+: {
+    'prometheus.io/scrape': 'true',
+    // Every component serves its own metrics on server_http_port (8080).
+    'prometheus.io/port': '8080',
+  } } } },
+};
+
 mimir {
   _config+:: {
     namespace: $._namespace,
@@ -88,6 +103,17 @@ mimir {
   querier_container+: k.util.resourcesRequests('100m', '128Mi'),
   query_frontend_container+: k.util.resourcesRequests('100m', '128Mi'),
   store_gateway_container+: k.util.resourcesRequests('100m', '128Mi'),
+}
+# Let Alloy scrape each Mimir component's own /metrics via pod annotations,
+# so Mimir's self-monitoring metrics end up in Mimir (see withScrapeAnnotations above).
++ {
+  compactor_statefulset+: withScrapeAnnotations,
+  distributor_deployment+: withScrapeAnnotations,
+  ingester_statefulset+: withScrapeAnnotations,
+  querier_deployment+: withScrapeAnnotations,
+  query_frontend_deployment+: withScrapeAnnotations,
+  query_scheduler_deployment+: withScrapeAnnotations,
+  store_gateway_statefulset+: withScrapeAnnotations,
 }
 # With the tiny setup in the homelab, podDisruptionBudget is causing issues with syncing.
 # Remove them for now and revisit in the future IF there are more nodes.


### PR DESCRIPTION
## Problem

The mimir-mixin dashboards added in #286 show no data. Generic app/node metrics remote-written through Mimir work fine (confirmed live via a direct query-frontend query), but Mimir's own operational metrics (`cortex_*`, `mimir_*`) — which those dashboards query — never existed in storage.

## Root cause

None of Mimir's pods (distributor, ingester, querier, query-frontend, query-scheduler, compactor, store-gateway) carry `prometheus.io/scrape` annotations, and there's no `ServiceMonitor` for `metrics-system`. Alloy's pod discovery only picks up targets via those two paths (`argo/apps/monitoring/values.yaml`), so nothing ever scraped Mimir's own `/metrics` endpoints — Mimir was storing everything sent to it, just never sending its own metrics to itself.

## Fix

Add `prometheus.io/scrape: "true"` / `prometheus.io/port: "8080"` to each Mimir component's pod template in `argo/apps/metrics/main.jsonnet`, matching the annotation-based scrape pattern Alloy already uses everywhere else.

## Validation

- `TANKA_NAMESPACE=metrics-system scripts/tk-show argo/apps/metrics` renders cleanly; confirmed exactly the 7 intended workloads (compactor, distributor, ingester, querier, query-frontend, query-scheduler, store-gateway) gained the annotation and nothing else changed.
- Live cluster: confirmed via direct query-frontend query that `cortex_build_info` currently returns zero results, i.e. the gap this PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)