### PR TITLE
metrics: reformat query-scheduler strategy override object

### DIFF
--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -101,7 +101,10 @@ mimir {
   query_scheduler_deployment+:
     deployment.mixin.spec.withReplicas(1)
     + deployment.mixin.spec.strategy.withType('Recreate')
-    + { spec+: { strategy+: { rollingUpdate: null }, template+: { spec+: { affinity: null } } } },
+    + { spec+: {
+        strategy+: { rollingUpdate: null },
+        template+: { spec+: { affinity: null } } }
+      },
 
   compactor_container+: k.util.resourcesRequests('100m', '128Mi'),
   distributor_container+: k.util.resourcesRequests('100m', '128Mi'),


### PR DESCRIPTION
Pure formatting change to the `query_scheduler_deployment` strategy-override object literal in `argo/apps/metrics/main.jsonnet` — no behavioral change.

## Validation

- `TANKA_NAMESPACE=metrics-system scripts/tk-show argo/apps/metrics` renders cleanly.
- Diffed the rendered manifests before/after this formatting change: **byte-for-byte identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)