### PR TITLE
metrics: enable Mimir ruler to evaluate mixin recording rules

### DIFF
--- a/argo/apps/metrics/jsonnetfile.json
+++ b/argo/apps/metrics/jsonnetfile.json
@@ -13,6 +13,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/mimir.git",
+          "subdir": "operations/mimir-mixin"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
           "subdir": "1.35"
         }

--- a/argo/apps/metrics/jsonnetfile.lock.json
+++ b/argo/apps/metrics/jsonnetfile.lock.json
@@ -1,0 +1,127 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "consul"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "FqEJAICz9T90PMJLW8i4HXazyWQPNzi68A8UauXa7GQ="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "memcached"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "mixin-utils"
+        }
+      },
+      "version": "93ba4993e0e0741f107ef61e19a022a71588e324",
+      "sum": "zVkvwae4zHP6xeIoDvde/wldI6ClprFjnk50mMD9/z4="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/mimir.git",
+          "subdir": "operations/mimir"
+        }
+      },
+      "version": "71aeb7ca0a0a33ba24225101d582b9149038c193",
+      "sum": "zKUldjMaIpT93QWhi8ZU/q2LP+KUzmoWh8BYzn0+F0A="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/mimir.git",
+          "subdir": "operations/mimir-mixin"
+        }
+      },
+      "version": "71aeb7ca0a0a33ba24225101d582b9149038c193",
+      "sum": "JWI1ZnyB23osWGvBgBOx2lZ0KSPCVkrMfXAQAsad++k="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/rollout-operator.git",
+          "subdir": "operations/rollout-operator"
+        }
+      },
+      "version": "0e952cd1cb19c8edb8d4173d350349d3c0901a27",
+      "sum": "4pYLZ+qmS226f9wDqjNLB8Uj5BtRUGr3I/xdKELIWkI="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/rollout-operator.git",
+          "subdir": "operations/rollout-operator-mixin"
+        }
+      },
+      "version": "a0d115714858140ccc686e30f24719bc303e734d",
+      "sum": "+A9iB+GdwZepQWGYAq/hinLOcdWQQQaApATnzvDMJEE="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.35"
+        }
+      },
+      "version": "ee5c4c5ee02571eaf82f1170c60af47eee5496be",
+      "sum": "B+1kudlxnkbH6warwOHHh+gmADl2w5VFJQ5D0SxcO6M="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/keda-libsonnet.git",
+          "subdir": "2.15"
+        }
+      },
+      "version": "dbc8cf1a9847f123d8325378111155fb135983ab",
+      "sum": "EVCNg9VpU9ghIYHZtbQffHbZs+EqKOD0cw+ZPilWR48=",
+      "name": "keda-libsonnet"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "4d7f8cb24d613430799f9d56809cc6964f35cea9",
+      "sum": "hOrwkOx34tOXqoDVnwuI/Uf/dr9HFFSPWpDPOvnEGrk="
+    }
+  ],
+  "legacyImports": false
+}

--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -3,11 +3,43 @@ local mimir = import 'mimir/mimir.libsonnet';
 
 local deployment = k.apps.v1.deployment;
 local statefulSet = k.apps.v1.statefulSet;
+local configMap = k.core.v1.configMap;
 
 // withSyncWave adds the sync-wave annotations to the metadata of the resource.
 local withSyncWave(wave) = {
   metadata+: { annotations+: { 'argocd.argoproj.io/sync-wave': std.toString(wave) } },
 };
+
+// The mimir-mixin's recording rules (the ones the mixin dashboards query,
+// e.g. cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate)
+// are never evaluated unless something loads them into the ruler. Build them
+// here from the same mixin config used un-overridden by argo/apps/monitoring
+// (see mixins.libsonnet there) so the recording rule names match exactly
+// what the dashboards query. Alerting rules are intentionally left out for
+// now: alertmanager_enabled is false below, and ruler.alertmanager-url
+// points at a service that doesn't exist, so alert rules would just fail to
+// notify.
+local mimirMixinRecordingRules =
+  (import 'mimir-mixin/config.libsonnet')
+  + (import 'mimir-mixin/groups.libsonnet')
+  + (import 'mimir-mixin/utils.libsonnet')
+  + (import 'mimir-mixin/recording_rules.libsonnet');
+
+// Mimir's ruler reads per-tenant rule files from <ruler_local_directory>/<tenant>/.
+// Multi-tenancy is disabled below, so everything is written under Mimir's
+// no-auth tenant (auth.no-auth-tenant default, "anonymous").
+local rulerRulesTenant = 'anonymous';
+// Distinct from the ruler's own scratch directory (ruler.rule-path, /rules)
+// where it materializes rule groups pulled from this directory, and from
+// /etc/mimir (the "overrides" ConfigMap mount) so this volume doesn't nest
+// inside another ConfigMap's mount path.
+local rulerRulesDir = '/etc/mimir-rules';
+
+local rulerRulesConfigMap =
+  configMap.new('mimir-recording-rules')
+  + configMap.withDataMixin({
+    'mimir-mixin.yaml': std.manifestYamlDoc({ groups: mimirMixinRecordingRules.prometheusRules.groups }),
+  });
 
 // withScrapeAnnotations adds prometheus.io/scrape annotations to a pod
 // template so Alloy's annotation-based pod discovery (see
@@ -58,6 +90,15 @@ mimir {
 
     compactor_data_disk_class: null,
     compactor_data_disk_size: '2Gi',
+
+    # Enable the ruler so the mixin's recording rules (which the mixin
+    # dashboards query) actually get evaluated. Rule groups are loaded from
+    # a ConfigMap-backed local directory (see rulerRulesConfigMap below)
+    # rather than the S3 backend, so there's no need for a mimirtool/CI job
+    # to push them -- they're just part of the GitOps sync.
+    ruler_enabled: true,
+    ruler_storage_backend: 'local',
+    ruler_local_directory: rulerRulesDir,
 
     # Scale down to 1 replica for the homelab setup.
     memcached_frontend_replicas: 1,
@@ -112,6 +153,11 @@ mimir {
   querier_container+: k.util.resourcesRequests('100m', '128Mi'),
   query_frontend_container+: k.util.resourcesRequests('100m', '128Mi'),
   store_gateway_container+: k.util.resourcesRequests('100m', '128Mi'),
+
+  ruler_deployment+:
+    deployment.mixin.spec.withReplicas(1)
+    + k.util.configMapVolumeMount(rulerRulesConfigMap, rulerRulesDir + '/' + rulerRulesTenant),
+  ruler_container+: k.util.resourcesRequests('100m', '128Mi'),
 }
 # Let Alloy scrape each Mimir component's own /metrics via pod annotations,
 # so Mimir's self-monitoring metrics end up in Mimir (see withScrapeAnnotations above).
@@ -123,6 +169,7 @@ mimir {
   query_frontend_deployment+: withScrapeAnnotations,
   query_scheduler_deployment+: withScrapeAnnotations,
   store_gateway_statefulset+: withScrapeAnnotations,
+  ruler_deployment+: withScrapeAnnotations,
 }
 # With the tiny setup in the homelab, podDisruptionBudget is causing issues with syncing.
 # Remove them for now and revisit in the future IF there are more nodes.
@@ -134,6 +181,7 @@ mimir {
   query_scheduler_pdb:: null,
   compactor_pdb:: null,
   store_gateway_pdb:: null,
+  ruler_pdb:: null,
   memcached+:: { podDisruptionBudget:: null },
 }
 
@@ -160,6 +208,19 @@ mimir {
 
   store_gateway_statefulset+: withSyncWave(1),
   store_gateway_service+: withSyncWave(1),
+
+  ruler_deployment+: withSyncWave(1),
+  ruler_service+: withSyncWave(1),
+}
+
+# The mixin recording rules ConfigMap mounted into the ruler (see
+# rulerRulesConfigMap above). Give it the same namespace and sync-wave as the
+# rest of the Mimir resources so it lands before the ruler tries to mount it.
++ {
+  mimir_recording_rules_configmap:
+    rulerRulesConfigMap
+    + configMap.mixin.metadata.withNamespace($._namespace)
+    + withSyncWave(1),
 }
 
 # Default values for the Tanka overrides. These can be overridden by the ArgoCD application.

--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -214,12 +214,13 @@ mimir {
 }
 
 # The mixin recording rules ConfigMap mounted into the ruler (see
-# rulerRulesConfigMap above). Give it the same namespace and sync-wave as the
-# rest of the Mimir resources so it lands before the ruler tries to mount it.
+# rulerRulesConfigMap above). Namespace comes from Tanka's environment
+# default (spec.json), same as every other resource in this app. Give it the
+# same sync-wave as the rest of the Mimir resources so it lands before the
+# ruler tries to mount it.
 + {
   mimir_recording_rules_configmap:
     rulerRulesConfigMap
-    + configMap.mixin.metadata.withNamespace($._namespace)
     + withSyncWave(1),
 }
 


### PR DESCRIPTION
## Problem

Mimir dashboards (Overview, Reads, Writes, Queries, Rollout Progress's
latency panels, etc.) query precomputed recording-rule series such as
`cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate`.
`ruler_enabled` was `false` in `argo/apps/metrics/main.jsonnet`, so nothing
ever evaluated the mixin's recording rules — Mimir itself was healthy and
correctly labeled, but most of its own dashboards looked dead.

## Fix

- Vendor `operations/mimir-mixin` alongside the existing `operations/mimir`
  dependency in `argo/apps/metrics` (two subdirs from the same repo — the
  repo root has no `jsonnetfile.json` of its own, so a single whole-repo
  vendor entry would drop `jb`'s transitive dependency resolution).
- Build the mixin's recording rules (config + groups + utils +
  recording_rules only — no alerting rules, since `alertmanager_enabled` is
  false and `ruler.alertmanager-url` points at a service that doesn't
  exist) from the same un-overridden mixin `_config` that
  `argo/apps/monitoring`'s dashboards use, so recording-rule names line up
  exactly with what the dashboards query.
- Enable the ruler and point it at a **local**, ConfigMap-backed rule
  storage directory (`/etc/mimir-rules/<tenant>`) instead of S3, so the
  rules are just part of the GitOps sync rather than needing a separate
  `mimirtool` push job.
- Size the ruler like its sibling components: 1 replica, 100m/128Mi
  requests, no PDB, sync-wave 1, Alloy scrape annotations.

## Validation

Rendered with `TANKA_NAMESPACE=metrics-system scripts/tk-show
argo/apps/metrics`:
- Ruler's ring uses `memberlist` (matches every other component; no consul
  dependency introduced).
- No S3 bucket needed for ruler storage (local backend skips that flag
  entirely).
- Rendered rules ConfigMap parses as valid YAML: 18 rule groups / 122
  rules, max group size 14 (limit is 20 — no override needed).
- The exact series that was confirmed empty,
  `cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate`,
  is present in the rendered rule file.

**Not verified** (would need a live cluster):
- Whether the ruler actually loads the ConfigMap-backed rule files at
  startup — check `cortex_prometheus_rule_group_rules` is non-zero in
  `metrics-system` once deployed.
- The ruler unconditionally picks up
  `-ruler-storage.cache.backend=memcached` alongside
  `-ruler-storage.backend=local` (upstream jsonnet applies caching config
  regardless of backend). If the ruler crashloops on first sync, that
  combination is the first thing to suspect
  (`ruler_storage_caching_config:: {}` would disable it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)