### PR TITLE
monitoring: fix job labels, empty Envoy panels, enable native histograms

### DIFF
--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -13,12 +13,16 @@ local withSyncWave(wave) = {
 // The mimir-mixin's recording rules (the ones the mixin dashboards query,
 // e.g. cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate)
 // are never evaluated unless something loads them into the ruler. Build them
-// here from the same mixin config used un-overridden by argo/apps/monitoring
-// (see mixins.libsonnet there) so the recording rule names match exactly
-// what the dashboards query. Alerting rules are intentionally left out for
-// now: alertmanager_enabled is false below, and ruler.alertmanager-url
-// points at a service that doesn't exist, so alert rules would just fail to
-// notify.
+// here from the same base mixin config imported by argo/apps/monitoring (see
+// mixins.libsonnet there) so the recording rule names match exactly what the
+// dashboards query. argo/apps/monitoring layers a `dashboards_default_latency_mode:
+// 'native'` override on top of this config, but that key only picks the
+// default value of a dashboard template variable -- it doesn't affect which
+// recording rules get generated (that's the separate record_native default,
+// already true in the vendored mixin), so the rule names built here still
+// match. Alerting rules are intentionally left out for now:
+// alertmanager_enabled is false below, and ruler.alertmanager-url points at
+// a service that doesn't exist, so alert rules would just fail to notify.
 local mimirMixinRecordingRules =
   (import 'mimir-mixin/config.libsonnet')
   + (import 'mimir-mixin/groups.libsonnet')

--- a/argo/apps/monitoring/alloy-config.alloy
+++ b/argo/apps/monitoring/alloy-config.alloy
@@ -84,8 +84,24 @@ discovery.relabel "pod_annotations" {
   }
   // Many dashboards select series by job=~"($namespace)/(component.*)"
   // rather than a flat job name. Reconstruct that "<namespace>/<name>"
-  // format whenever a pod carries a "name" label identifying its
-  // component. Pods without one keep the flat job_name set below.
+  // format whenever a pod carries a label identifying its component.
+  //
+  // Most workloads here are plain Helm charts, which stamp the standard
+  // app.kubernetes.io/name label, not the bare "name" label used by
+  // ksonnet-util/kausal-based apps (e.g. this repo's own Mimir jsonnet).
+  // Apply the Helm-style rule first, then let the kausal-style "name"
+  // rule override it for the apps that actually carry that label -- a
+  // later `replace` only takes effect when its own regex matches, so
+  // this ordering means every Helm pod gets a real job label instead of
+  // silently falling through to the flat job_name ("pod-metrics") below,
+  // while kausal-style pods still win with their own convention.
+  rule {
+    source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    action = "replace"
+    target_label = "job"
+    regex = "(.+);(.+)"
+    replacement = "$1/$2"
+  }
   rule {
     source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_name"]
     action = "replace"
@@ -106,6 +122,21 @@ prometheus.scrape "kubelet" {
     ca_file        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     insecure_skip_verify = true
   }
+  // Convert classic (bucketed) histograms to native histograms with
+  // custom buckets (NHCB) at scrape time, so mixin dashboards/recording
+  // rules that query native histograms (histogram_quantile/_count over
+  // the bare metric name) actually have data, without requiring every
+  // scraped target to change its own instrumentation. Mimir's ingester
+  // accepts native histogram samples by default
+  // (ingester.native-histograms-ingestion-enabled=true).
+  //
+  // scrape_classic_histograms keeps the original classic _bucket/_sum/
+  // _count series alongside the synthesized native one -- without it,
+  // conversion *replaces* classic series instead of adding to them,
+  // which would break every classic-histogram query (recording rules,
+  // latency panels, _count-based QPS panels) that isn't native-aware.
+  convert_classic_histograms_to_nhcb = true
+  scrape_classic_histograms = true
   forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.remote_write.mimir.receiver]
 }
 
@@ -120,6 +151,9 @@ prometheus.scrape "cadvisor" {
     ca_file        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     insecure_skip_verify = true
   }
+  // See the kubelet scrape above for why these are set.
+  convert_classic_histograms_to_nhcb = true
+  scrape_classic_histograms = true
   forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.remote_write.mimir.receiver]
 }
 
@@ -129,6 +163,9 @@ prometheus.scrape "node_exporter" {
     __address__ = "node-exporter.monitoring.svc.cluster.local:9100",
   }]
   job_name   = "node-exporter"
+  // See the kubelet scrape above for why these are set.
+  convert_classic_histograms_to_nhcb = true
+  scrape_classic_histograms = true
   forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.remote_write.mimir.receiver]
 }
 
@@ -142,6 +179,9 @@ prometheus.scrape "kube_state_metrics" {
     __address__ = "kube-state-metrics.monitoring.svc.cluster.local:8080",
   }]
   job_name   = "kube-state-metrics"
+  // See the kubelet scrape above for why these are set.
+  convert_classic_histograms_to_nhcb = true
+  scrape_classic_histograms = true
   forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.remote_write.mimir.receiver]
 }
 
@@ -149,10 +189,19 @@ prometheus.scrape "kube_state_metrics" {
 prometheus.scrape "pods" {
   targets    = discovery.relabel.pod_annotations.output
   job_name   = "pod-metrics"
+  // See the kubelet scrape above for why these are set. This is the path
+  // Envoy and Mimir's own self-scrape (see argo/apps/metrics/main.jsonnet)
+  // go through, so this is what actually makes their histogram-backed
+  // dashboard panels (latency quantiles, etc.) have data.
+  convert_classic_histograms_to_nhcb = true
+  scrape_classic_histograms = true
   forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.remote_write.mimir.receiver]
 }
 
-// Scrape ServiceMonitor targets
+// Scrape ServiceMonitor targets. No classic->native conversion knob exists
+// for this component (only scrape_native_histograms, for targets that
+// already emit native histograms natively, which none of ours do), so
+// ArgoCD's metrics stay classic-histogram-only here.
 prometheus.operator.servicemonitors "services" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 }

--- a/argo/apps/monitoring/mixins.libsonnet
+++ b/argo/apps/monitoring/mixins.libsonnet
@@ -4,8 +4,46 @@
 // together. Merging them flatly (the previous shape here) meant
 // addMixinDashboards's `mixins[name].grafanaDashboards` lookup never matched
 // anything, so no dashboard ever made it into a ConfigMap.
+local envoyMixin = import 'github.com/grafana/jsonnet-libs/envoy-mixin/mixin.libsonnet';
+
+// envoy-mixin's dashboards.libsonnet hand-writes the "job" and "instance"
+// template variables with current='' (a literal empty string), unlike
+// envoy_cluster/envoy_listener_filter in the same file which correctly
+// default to "All" ($__all). Grafana takes '' at face value -- every panel
+// filtering on job=~"$job"/instance=~"$instance" resolves to matching only
+// an empty label value, so every Envoy panel comes back empty until a user
+// manually reselects "All" in the UI once. Patch the default to match the
+// other variables (both are includeAll=true with allValues='.+' already).
+local fixEmptyVarDefault(dashboard) =
+  dashboard {
+    templating+: {
+      list: [
+        if (v.name == 'job' || v.name == 'instance') && v.current.value == ''
+        then v { current: { selected: true, text: 'All', value: '$__all' } }
+        else v
+        for v in dashboard.templating.list
+      ],
+    },
+  };
+
 {
   argocd: import 'github.com/grafana/jsonnet-libs/argocd-mixin/mixin.libsonnet',
-  envoy: import 'github.com/grafana/jsonnet-libs/envoy-mixin/mixin.libsonnet',
-  mimir: import 'github.com/grafana/mimir/operations/mimir-mixin/mixin.libsonnet',
+  envoy: envoyMixin {
+    grafanaDashboards+:: {
+      [name]: fixEmptyVarDefault(envoyMixin.grafanaDashboards[name])
+      for name in std.objectFields(envoyMixin.grafanaDashboards)
+    },
+  },
+  mimir: (import 'github.com/grafana/mimir/operations/mimir-mixin/mixin.libsonnet') + {
+    _config+:: {
+      // Alloy converts classic histograms to native histograms with
+      // custom buckets (NHCB) at scrape time (see
+      // convert_classic_histograms_to_nhcb in alloy-config.alloy), so
+      // default the dashboards' latency panels to the native query path
+      // rather than classic buckets. Historical data recorded before
+      // that change stays classic-only and won't show under this mode --
+      // acceptable here since this homelab doesn't need it preserved.
+      dashboards_default_latency_mode: 'native',
+    },
+  },
 }


### PR DESCRIPTION
## Summary

Diagnosed against the live `bet1` cluster (job-label cardinality, direct Mimir queries, rendered dashboard JSON) rather than static reading alone. Three independent bugs, all in `argo/apps/monitoring`:

- **`job` label stuck as `pod-metrics`**: the Alloy relabel rule reconstructing `job=<namespace>/<component>` only matched a pod label literally called `name` (the ksonnet-util/kausal convention Mimir's own jsonnet uses). Every Helm-deployed workload carries `app.kubernetes.io/name` instead, so it silently fell through to the flat `pod-metrics` job for everything else — confirmed live via `count by(job)(up)`.
- **Empty Envoy panels**: not a data problem — `envoy_*` metrics were present in Mimir the whole time. The vendored `envoy-mixin` hand-codes its `job`/`instance` dashboard template variables with a literal `current=''` instead of "All" like every other variable in the same dashboard, so every panel filtering on `job=~"$job"` resolved to matching nothing.
- **Mostly-empty Mimir panels / broken under native histograms**: this Mimir install wasn't emitting native histogram samples at all, so the mixin's native-histogram recording rules and dashboard queries (`histogram_count(rate(metric[...]))` on the bare metric name) had nothing to match.

## Changes

- `alloy-config.alloy`: add an `app.kubernetes.io/name`-based job relabel rule ahead of the existing `name`-based one (Mimir's own components still win via their own convention; everything else stops falling into `pod-metrics`).
- `alloy-config.alloy`: enable `convert_classic_histograms_to_nhcb` + `scrape_classic_histograms` on every `prometheus.scrape` block — converts classic histograms to native histograms with custom buckets (NHCB) at scrape time while keeping the original classic series alive (verified against Alloy's source that `scrape_classic_histograms` maps to Prometheus's `AlwaysScrapeClassicHistograms`, so nothing regresses). ServiceMonitor-scraped targets (ArgoCD) have no equivalent knob and stay classic-only.
- `mixins.libsonnet`: default Mimir dashboards' latency panels to the native query path (`dashboards_default_latency_mode: 'native'`) now that native data exists. Per user instruction, historical classic-only data isn't preserved under this mode — acceptable for this homelab.
- `mixins.libsonnet`: patch the Envoy dashboard's `job`/`instance` template variables to default to "All" instead of the mixin's broken `''` default.
- `main.jsonnet`: update a comment that had gone stale once `mixins.libsonnet`'s mimir config was no longer "un-overridden".

## Validation

- `scripts/tk-show` for both `argo/apps/monitoring` and `argo/apps/metrics` renders cleanly end-to-end after every change.
- Rendered dashboard JSON confirms: Envoy `job`/`instance` variables now default to `$__all`; Mimir dashboards' `latency_metrics` variable now defaults to `native`.
- Live Mimir queries (before writing the fix) confirmed the underlying `envoy_*`/`cortex_*` metrics were present all along — this was a query/config problem, not a missing-data problem.
- Not yet verified against a live sync: once Argo picks this up, worth checking `count({__name__="cortex_request_duration_seconds"})` goes non-zero and `sum by (reason) (rate(cortex_discarded_samples_total[5m]))` shows no `native_histogram` rejections (would indicate Mimir's bucket-count limit needs an explicit override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)