### PR TITLE
monitoring: switch Grafana deployment to Recreate strategy

### DIFF
--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -121,11 +121,22 @@ config + {
       // fsGroup is required because the grafana image runs as uid 472, but a
       // fresh PVC mounts root-owned — without it the container can't write
       // to /var/lib/grafana and crashloops on "Permission denied".
+      //
+      // Recreate instead of the default RollingUpdate: grafana-data is a
+      // single RWO PVC and Grafana takes an exclusive file lock on its
+      // bleve search index inside it, so a rolling update that starts the
+      // new pod before killing the old one leaves the new pod permanently
+      // crashlooping on "index is locked by another process" (same
+      // single-node-homelab failure mode as query_scheduler_deployment in
+      // argo/apps/metrics/main.jsonnet). Recreate tears down the old pod
+      // first, releasing the lock before the new one starts.
       grafana_deployment+:
         k.apps.v1.deployment.mixin.spec.template.spec.withVolumesMixin([
           volume.fromPersistentVolumeClaim('grafana-data', 'grafana-data'),
         ])
         + k.apps.v1.deployment.mixin.spec.template.spec.securityContext.withFsGroup(472)
+        + k.apps.v1.deployment.mixin.spec.strategy.withType('Recreate')
+        + { spec+: { strategy+: { rollingUpdate: null } } }
         + withSyncWave(2),
     }
 }


### PR DESCRIPTION
## Summary

Diagnosed live: after #293 synced, `grafana-68668844f6-skdd4` came up and immediately started CrashLoopBackOff while the previous pod (`grafana-7d84845c9d-9sxvz`) kept running healthily.

```
logger=bleve-backend level=error msg="index is locked by another process" ...
Error: ✗ index is locked by another process: indexDir=/var/lib/grafana/unified-search/bleve/default/dashboards.dashboard.grafana.app/20260814-231850, err=timeout
```

`grafana_deployment` uses the default `RollingUpdate` strategy, but `grafana-data` is a single RWO PVC and Grafana takes an exclusive file lock on its bleve search index inside it. Since this is a single-node cluster, the new pod's RWO mount succeeds fine (same node) while the old pod is still running and holding the lock — so the new pod can never actually start.

This is the exact failure mode already documented and worked around for `query_scheduler_deployment` in `argo/apps/metrics/main.jsonnet`: hard pod anti-affinity/rolling-update assumptions that don't hold on a one-node homelab. Same fix here.

## Change

`grafana.libsonnet`: switch `grafana_deployment`'s strategy to `Recreate` (old pod torn down, releasing the lock, before the new one starts).

## Validation

- `scripts/tk-show argo/apps/monitoring` renders cleanly; confirmed the Deployment manifest now carries `strategy: {type: Recreate, rollingUpdate: null}`.
- Not a config regression: `rollingUpdate: null` is the same shape already live and working for `query_scheduler_deployment`.

## Note

Applying this will briefly restart the currently-healthy Grafana pod (Recreate tears it down before bringing the new one up) — a few seconds of Grafana being unreachable, not a data-loss risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)