### PR TITLE
monitoring: fix Grafana Recreate strategy and empty dashboards

### DIFF
--- a/argo/apps/monitoring/alloy-config.alloy
+++ b/argo/apps/monitoring/alloy-config.alloy
@@ -18,20 +18,30 @@ discovery.kubernetes "pods" {
 }
 
 // Relabel node internal IP to kubelet address
+//
+// discovery.kubernetes's node role exposes each node's addresses as
+// __meta_kubernetes_node_address_<Type> (e.g. ..._address_InternalIP), not
+// ..._internal_ip -- that label name doesn't exist, so source_labels was
+// always resolving to empty, leaving __address__ as ":10250" (no host).
+// Confirmed live via Alloy's component debug API
+// (/api/v0/web/components/prometheus.scrape.cadvisor), which showed
+// exactly that empty-host address, and up{job=~".*kubelet.*|.*cadvisor.*"}
+// == 0 in Mimir -- these scrapes have never actually succeeded.
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
   rule {
-    source_labels = ["__meta_kubernetes_node_internal_ip"]
+    source_labels = ["__meta_kubernetes_node_address_InternalIP"]
     target_label  = "__address__"
     replacement   = "$1:10250"
   }
 }
 
-// Relabel node internal IP for cadvisor
+// Relabel node internal IP for cadvisor. See the kubelet relabel above for
+// why source_labels names __meta_kubernetes_node_address_InternalIP.
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
   rule {
-    source_labels = ["__meta_kubernetes_node_internal_ip"]
+    source_labels = ["__meta_kubernetes_node_address_InternalIP"]
     target_label  = "__address__"
     replacement   = "$1:10250"
   }

--- a/argo/apps/monitoring/grafana.libsonnet
+++ b/argo/apps/monitoring/grafana.libsonnet
@@ -121,11 +121,22 @@ config + {
       // fsGroup is required because the grafana image runs as uid 472, but a
       // fresh PVC mounts root-owned — without it the container can't write
       // to /var/lib/grafana and crashloops on "Permission denied".
+      //
+      // Recreate instead of the default RollingUpdate: grafana-data is a
+      // single RWO PVC and Grafana takes an exclusive file lock on its
+      // bleve search index inside it, so a rolling update that starts the
+      // new pod before killing the old one leaves the new pod permanently
+      // crashlooping on "index is locked by another process" (same
+      // single-node-homelab failure mode as query_scheduler_deployment in
+      // argo/apps/metrics/main.jsonnet). Recreate tears down the old pod
+      // first, releasing the lock before the new one starts.
       grafana_deployment+:
         k.apps.v1.deployment.mixin.spec.template.spec.withVolumesMixin([
           volume.fromPersistentVolumeClaim('grafana-data', 'grafana-data'),
         ])
         + k.apps.v1.deployment.mixin.spec.template.spec.securityContext.withFsGroup(472)
+        + k.apps.v1.deployment.mixin.spec.strategy.withType('Recreate')
+        + { spec+: { strategy+: { rollingUpdate: null } } }
         + withSyncWave(2),
     }
 }

--- a/argo/apps/monitoring/mixins.libsonnet
+++ b/argo/apps/monitoring/mixins.libsonnet
@@ -5,6 +5,7 @@
 // addMixinDashboards's `mixins[name].grafanaDashboards` lookup never matched
 // anything, so no dashboard ever made it into a ConfigMap.
 local envoyMixin = import 'github.com/grafana/jsonnet-libs/envoy-mixin/mixin.libsonnet';
+local argocdMixin = import 'github.com/grafana/jsonnet-libs/argocd-mixin/mixin.libsonnet';
 
 // envoy-mixin's dashboards.libsonnet hand-writes the "job" and "instance"
 // template variables with current='' (a literal empty string), unlike
@@ -26,8 +27,34 @@ local fixEmptyVarDefault(dashboard) =
     },
   };
 
+// argocd-mixin's dashboard hand-codes the "datasource" template variable's
+// current value as "grafanacloud-k8sintegrations-prom" -- a leftover from
+// the Grafana Cloud onboarding flow this dashboard was authored for. That
+// name doesn't match any datasource provisioned here (only "Metrics",
+// added via grafana.addDatasource in grafana.libsonnet), so every panel's
+// `${datasource}` reference fails to resolve and comes back empty,
+// regardless of whether the underlying metrics exist in Mimir. Point it at
+// "default" instead, like the Envoy and Mimir dashboards already do, so it
+// picks up whichever datasource is marked default=true.
+local fixDatasourceVarDefault(dashboard) =
+  dashboard {
+    templating+: {
+      list: [
+        if v.type == 'datasource' && v.name == 'datasource'
+        then v { current: { selected: false, text: 'default', value: 'default' } }
+        else v
+        for v in dashboard.templating.list
+      ],
+    },
+  };
+
 {
-  argocd: import 'github.com/grafana/jsonnet-libs/argocd-mixin/mixin.libsonnet',
+  argocd: argocdMixin {
+    grafanaDashboards+:: {
+      [name]: fixDatasourceVarDefault(argocdMixin.grafanaDashboards[name])
+      for name in std.objectFields(argocdMixin.grafanaDashboards)
+    },
+  },
   envoy: envoyMixin {
     grafanaDashboards+:: {
       [name]: fixEmptyVarDefault(envoyMixin.grafanaDashboards[name])


### PR DESCRIPTION
## Summary

- Switch the Grafana deployment to the `Recreate` rollout strategy.
- Fix two independent causes of empty dashboards, found by querying the live `bet1` cluster's Mimir and Alloy:
  - **kubelet/cadvisor scrapes never worked.** `alloy-config.alloy`'s node relabel rules read `__meta_kubernetes_node_internal_ip`, which doesn't exist — node-role discovery exposes it as `__meta_kubernetes_node_address_InternalIP`. `__address__` was resolving to `":10250"` (empty host), confirmed via Alloy's component debug API, and `up{job=~"kubelet|cadvisor"}` was `0` in Mimir. No cAdvisor container metrics (`container_memory_working_set_bytes`, etc.) have ever landed, independent of the job-label/histogram fixes in earlier PRs, which addressed other scrape targets.
  - **ArgoCD dashboard datasource variable pointed nowhere.** The vendored `argocd-mixin` dashboard hand-codes its `datasource` template variable to `grafanacloud-k8sintegrations-prom`, a Grafana Cloud onboarding leftover that doesn't match this cluster's only datasource (`Metrics`). Every panel references `${datasource}`, so it never resolved and the whole dashboard came back empty even though `argocd_*` metrics are present in Mimir. Patched to `"default"`, matching the convention the Envoy and Mimir dashboards already use.

## Validation

- Rendered both apps via `scripts/tk-show` — no errors.
- Evaluated `mixins.libsonnet` directly to confirm the ArgoCD dashboard's datasource variable now carries `{"text": "default", "value": "default"}`.
- Confirmed pre-fix via live queries: `up{job=~".*kubelet.*|.*cadvisor.*"} == 0`, empty-host `__address__` in Alloy's debug API, and zero `container_*` series in Mimir.
- Not yet confirmed live post-deploy: `up` going to `1` and `container_memory_working_set_bytes` becoming non-empty once Argo CD syncs this and Alloy's config reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)