### PR TITLE
homeassistant: enable Prometheus ServiceMonitor scraping

### DIFF
--- a/argo/apps/homeassistant/values.yaml
+++ b/argo/apps/homeassistant/values.yaml
@@ -26,6 +26,23 @@ homeassistant:
     accessMode: ReadWriteOnce
     size: 5Gi
 
+  # Exposes the built-in Prometheus integration (chart auto-enables
+  # `prometheus:` in configuration.yaml once this is on) at /api/prometheus
+  # and creates a ServiceMonitor for it. Alloy already watches
+  # ServiceMonitor targets cluster-wide (prometheus.operator.servicemonitors
+  # in alloy-config.alloy), so no scrape config changes are needed there.
+  # HA's API requires auth on every request, so the endpoint is secured with
+  # a bearer token pulled from the same long-lived access token used by
+  # Matter Hub below (homeassistant-matterhub secret, key: token) -- HA
+  # tokens aren't scope-limited, so reusing it avoids provisioning a second
+  # one just for scraping.
+  serviceMonitor:
+    enabled: true
+    scrapeInterval: 30s
+    bearerToken:
+      secretName: homeassistant-matterhub
+      secretKey: token
+
 matter:
   # Can this be hardcoded? Will we need to do some funky lookups?
   networkInterface: enp6s0
@@ -38,6 +55,8 @@ matter:
 # The Home Assistant URL and access token are automatically pulled from the
 # shared-secrets in kube-system namespace via External Secrets Operator.
 # Keys used: homeassistant_url and homeassistant_token
+# The resulting homeassistant-matterhub secret's `token` key is also reused
+# above by homeassistant.serviceMonitor.bearerToken for Prometheus scraping.
 matterhub:
   enabled: true
   image:


### PR DESCRIPTION
## Summary

- Enables the `home-assistant` chart's built-in `serviceMonitor`, which auto-adds a bare `prometheus:` line to `configuration.yaml` (enabling HA's Prometheus integration) and creates a `ServiceMonitor` targeting `/api/prometheus`.
- Alloy already discovers `ServiceMonitor` resources cluster-wide via `prometheus.operator.servicemonitors` in `alloy-config.alloy` — no Alloy config changes needed. Verified against Alloy's source (`config_gen_servicemonitor.go`) that it resolves `bearerTokenSecret`, and the installed `prometheus-operator-crds` version still ships that field.
- Plain `prometheus.io/scrape` pod annotations weren't usable here: Alloy's shared `prometheus.scrape "pods"` job has no per-target auth, and HA requires a bearer token on every API request.
- **Credentials**: reuses the existing `homeassistant-matterhub` secret's `token` key for `bearerTokenSecret`, rather than provisioning a new secret — HA long-lived access tokens aren't scope-limited, so the token already used by Matter Hub works here too.

## Live-cluster note

The chart's init script only writes its templated `configuration.yaml` when the file doesn't already exist, or when `forceInit: true`. This HA instance has been running with a hand-edited `configuration.yaml` (manual `zha:` block) for a while, so this values.yaml change alone wouldn't reach the running pod. With the user's go-ahead, I exec'd into `homeassistant-0`, backed up the live file to `configuration.yaml.bak-preprometheus`, inserted the `prometheus:` line by hand, and restarted the pod. `/api/prometheus` now returns `401 Unauthorized` (previously unrouted), confirming the integration loaded and is enforcing auth as expected.

## Testing

- `helm dependency build` + `helm template` against the actual `values.yaml`: confirmed the `ServiceMonitor` renders in the `homeassistant` namespace with selector labels matching the real Service, and `prometheus:` appears in the rendered `configuration.yaml` template.
- Did not verify the token itself works end-to-end against `/api/prometheus` (reading secret content is out of scope per repo conventions) — once this is synced via Argo CD, `up{job=~".*homeassistant.*"}` in Mimir/Grafana is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)