### PR TITLE
metrics/monitoring: fix Mimir series-budget exhaustion

### DIFF
--- a/argo/apps/metrics/main.jsonnet
+++ b/argo/apps/metrics/main.jsonnet
@@ -120,6 +120,27 @@ mimir {
     commonConfig+:: {
       'auth.multitenancy-enabled': false,
     },
+
+    # Bump the per-tenant series budget from the extra_small_user default
+    # (150k) to the medium_small_user tier's series/metadata caps (300k),
+    # layered on top of extra_small_user rather than switching tiers
+    # outright -- medium_small_user has no compactor_blocks_retention_period,
+    # which compactor.libsonnet requires unconditionally, so a bare
+    # `overrides.medium_small_user` breaks compactor rendering.
+    #
+    # We hit the 150k ceiling exactly once the kubelet/cadvisor scrape fix
+    # (see argo/apps/monitoring alloy-config.alloy history) started actually
+    # ingesting data for the first time -- the distributor then rejects any
+    # push containing series it hasn't seen before, cluster-wide, which
+    # silently blocks onboarding anything new (e.g. homeassistant's
+    # ServiceMonitor). alloy-config.alloy also trims the biggest offender
+    # (k3s's kubelet endpoint leaking apiserver/etcd/scheduler control-plane
+    # metrics), but bump the ceiling too so there's real headroom instead of
+    # living right at 150k again.
+    limits: $._config.overrides.extra_small_user + {
+      max_global_series_per_user: 300000,
+      max_global_metadata_per_user: std.ceil(self.max_global_series_per_user * 0.2),
+    },
   },
 
   

--- a/argo/apps/monitoring/alloy-config.alloy
+++ b/argo/apps/monitoring/alloy-config.alloy
@@ -147,7 +147,28 @@ prometheus.scrape "kubelet" {
   // latency panels, _count-based QPS panels) that isn't native-aware.
   convert_classic_histograms_to_nhcb = true
   scrape_classic_histograms = true
-  forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.remote_write.mimir.receiver]
+  forward_to = [prometheus.relabel.cloud_filter.receiver, prometheus.relabel.kubelet_filter.receiver]
+}
+
+// Drop k3s's embedded control-plane metrics that leak onto the kubelet's
+// own :10250/metrics endpoint. k3s runs the API server, etcd, scheduler,
+// and kubelet as a single binary/process on server nodes, so scraping the
+// "kubelet" target above also picks up apiserver_*/etcd_*/scheduler_*
+// metrics with full verb/resource/code histogram-bucket cardinality --
+// confirmed via Mimir (count({job="integrations/kubernetes/kubelet"}) by
+// prefix) these accounted for ~90% of this job's ~71k series, none of
+// which any dashboard/recording rule here queries. Dropping them recovers
+// a large chunk of the per-tenant series budget (see max_global_series_per_user
+// in argo/apps/metrics/main.jsonnet) without losing anything currently used.
+// workqueue_*/rest_client_* are dropped for the same reason -- generic
+// client-go instrumentation, not kubelet-specific.
+prometheus.relabel "kubelet_filter" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+  rule {
+    source_labels = ["__name__"]
+    action = "drop"
+    regex = "(apiserver|etcd|scheduler|workqueue|rest_client)_.*"
+  }
 }
 
 // Scrape cadvisor container metrics


### PR DESCRIPTION
## Summary

Discovered while verifying #296 (homeassistant Prometheus scraping): the ServiceMonitor was deployed correctly and Alloy generated a valid scrape config with no errors, but no `up` series for it ever landed in Mimir. Root cause: the per-tenant ingester series budget was sitting at exactly 150000/150000, so the distributor was rejecting *any* push containing a series it hadn't seen before, cluster-wide — not specific to homeassistant.

That cap was hit because `eda768b` (fixing the kubelet/cadvisor scrape) started actually ingesting data for those jobs for the first time. Turns out most of what they ingest isn't kubelet/cadvisor data at all: k3s runs the API server, etcd, scheduler, and kubelet as a single binary/process on server nodes, so scraping the kubelet's own `:10250/metrics` endpoint also picks up full-cardinality control-plane metrics (`apiserver_request_duration_seconds_bucket` per verb/resource/code, `etcd_request_duration_seconds_bucket`, etc.) that nothing in this repo's dashboards or recording rules queries. Confirmed via Mimir (`count({job="integrations/kubernetes/kubelet"})` broken down by `__name__` prefix): `apiserver_*` + `etcd_*` alone were ~64k of the job's ~71k series.

## Changes

- **`argo/apps/monitoring/alloy-config.alloy`**: new `prometheus.relabel "kubelet_filter"` component drops `apiserver_*`/`etcd_*`/`scheduler_*`/`workqueue_*`/`rest_client_*` from the kubelet scrape before it reaches Mimir's remote_write (the Grafana Cloud path via `cloud_filter` is untouched — it already keeps only `kubelet_volume_stats_*`).
- **`argo/apps/metrics/main.jsonnet`**: bumps `max_global_series_per_user` from 150k to 300k, layered on top of the existing `extra_small_user` tier rather than switching to `medium_small_user` outright (that tier is missing `compactor_blocks_retention_period`, which `compactor.libsonnet` requires unconditionally and would break rendering). This gives real headroom instead of landing right back at the ceiling.

## Testing

- `alloy validate` (via `docker run ... grafana/alloy:v1.18.1`) passes cleanly on the edited config, and fails as expected against a deliberately broken copy — confirming the check actually exercises the file.
- `scripts/tk-show` renders `argo/apps/metrics` cleanly, with `-ingester.max-global-series-per-user=300000` present in the rendered ingester args.
- Live cluster: confirmed current series count was exactly `150000` via `cortex_ingester_memory_series`, and confirmed the `apiserver_*`/`etcd_*` cardinality breakdown on the live `kubelet` job before writing the drop rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)